### PR TITLE
Not every request has a session. Every request has a context

### DIFF
--- a/src/Request/RequestValidator.php
+++ b/src/Request/RequestValidator.php
@@ -99,7 +99,7 @@ class RequestValidator
      */
     private function validateApplicationId($applicationId)
     {
-        if( $this->request->session->application->applicationId != $applicationId) {
+        if( $this->request->context->application->applicationId != $applicationId) {
             $this->errors[] = 'Invalid application id';
             return false;
         }


### PR DESCRIPTION
I have only been working with Alexa for two weeks now so I may be wrong. However, I noticed in my logging that I was getting a lot of invalid app id errors. When I dug into it I found that not all requests coming from Amazon have a session - e.g. AudioPlayer.PlaybackStarted - but all requests have context. Once I changed the RequestValidator to check that instead, all errors stopped. 

Thanks for the great library.

Cheers!
=C=